### PR TITLE
Rotation Fix PlatformLink.cs

### DIFF
--- a/Scripts/PlatformLink.cs
+++ b/Scripts/PlatformLink.cs
@@ -62,7 +62,7 @@ public class PlatformLink : UdonSharpBehaviour
             //last location on platform + how much player moved from last frame.
             Vector3 teleportPoint = linkedObject.TransformPoint(lastLocalPos) + (avatarRoot.position - lastWorldPos);
             //last rotation vector on platform projected onto +y normal + how much player has rotated from last frame.
-            Quaternion teleportRot = Quaternion.LookRotation(Vector3.ProjectOnPlane(linkedObject.TransformDirection(lastLocalRot), Vector3.up)) * (avatarRoot.rotation * Quaternion.Inverse(lastWorldRot));
+            Quaternion teleportRot = (Quaternion.LookRotation(Vector3.ProjectOnPlane(linkedObject.TransformDirection(lastLocalRot), Vector3.up)) * (avatarRoot.rotation * Quaternion.Inverse(lastWorldRot))).normalized;
             float velocityZ, velocityX;
             Vector3 currentVelocity = localPlayer.GetVelocity();
 
@@ -149,7 +149,7 @@ public class PlatformLink : UdonSharpBehaviour
         if (linkedObject != null)
         {
             Vector3 teleportPoint = linkedObject.TransformPoint(lastLocalPos) + (avatarPos - lastWorldPos);
-            Quaternion teleportRot = Quaternion.LookRotation(Vector3.ProjectOnPlane(linkedObject.TransformDirection(lastLocalRot), Vector3.up)) * (avatarRot * Quaternion.Inverse(lastWorldRot));
+            Quaternion teleportRot = (Quaternion.LookRotation(Vector3.ProjectOnPlane(linkedObject.TransformDirection(lastLocalRot), Vector3.up)) * (avatarRot * Quaternion.Inverse(lastWorldRot))).normalized;
 
             localPlayer.TeleportTo(teleportPoint, teleportRot, VRC_SceneDescriptor.SpawnOrientation.AlignPlayerWithSpawnPoint, true);
 


### PR DESCRIPTION
Normalized the quaternions to fix a bug: the slight discrepancies in quaternion calculations were causing the player's view to rotate out of alignment with the platform. Even when the platform was perfectly still, this would cause the player camera to rotate. Normalizing these values appears to have completely fixed the issue.